### PR TITLE
Translate theme UI text into Vietnamese

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -26,15 +26,15 @@
                         {{/if}}
                     </a>
                 </div>
-                <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger" aria-label="Toggle menu"></button>
+                <button class="gh-search gh-icon-btn" aria-label="Tìm kiếm trên trang này" data-ghost-search>{{> "icons/search"}}</button>
+                <button class="gh-burger" aria-label="Bật/tắt menu"></button>
             </div>
 
             <nav class="gh-head-menu">
                 {{navigation}}
                 {{#unless @site.members_enabled}}
                     {{#match @custom.navigation_layout "Stacked"}}
-                        <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
+                        <button class="gh-search gh-icon-btn" aria-label="Tìm kiếm trên trang này" data-ghost-search>{{> "icons/search"}}</button>
                     {{/match}}
                 {{/unless}}
             </nav>
@@ -42,7 +42,7 @@
             <div class="gh-head-actions">
                 {{#unless @site.members_enabled}}
                     {{^match @custom.navigation_layout "Stacked"}}
-                        <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
+                        <button class="gh-search gh-icon-btn" aria-label="Tìm kiếm trên trang này" data-ghost-search>{{> "icons/search"}}</button>
                     {{/match}}
                 {{else}}
                     <button class="gh-search gh-icon-btn" aria-label="Tìm kiếm trên trang này" data-ghost-search>{{> "icons/search"}}</button>
@@ -77,7 +77,7 @@
                     <a class="gh-subscribe-input" href="#/portal/signup" data-portal="signup">
                         <div class="gh-subscribe-input-text">
                             {{> icons/email}}
-                            jamie@example.com
+                            ban@example.com
                         </div>
                         <div class="gh-subscribe-input-btn">Đăng ký</div>
                     </a>

--- a/index.hbs
+++ b/index.hbs
@@ -79,7 +79,7 @@
                                     <a class="gh-subscribe-input" href="#/portal/signup" data-portal="signup">
                                         <div class="gh-subscribe-input-text">
                                             {{> icons/email}}
-                                            jamie@example.com
+                                            ban@example.com
                                         </div>
                                         <div class="gh-subscribe-input-btn">Đăng ký</div>
                                     </a>

--- a/partials/content-cta.hbs
+++ b/partials/content-cta.hbs
@@ -4,21 +4,21 @@
 
 <section class="gh-cta">
     {{#has visibility="paid"}}
-        <h4 class="gh-cta-title">This post is for paying subscribers only</h4>
+        <h4 class="gh-cta-title">Bài viết này chỉ dành cho người đăng ký trả phí</h4>
     {{/has}}
     {{#has visibility="members"}}
-        <h4 class="gh-cta-title">This post is for subscribers only</h4>
+        <h4 class="gh-cta-title">Bài viết này chỉ dành cho người đăng ký</h4>
     {{/has}}
     {{#has visibility="filter"}}
-        <h4 class="gh-cta-title">This post is for subscribers on the {{tiers}} only</h4>
+        <h4 class="gh-cta-title">Bài viết này chỉ dành cho những người đăng ký gói {{tiers}}</h4>
     {{/has}}
 
     <div class="gh-cta-actions">
         {{#if @member}}
-            <button class="gh-btn gh-primary-btn" href="#/portal/account/plans" data-portal="account/plans">Upgrade now</button>
+            <button class="gh-btn gh-primary-btn" href="#/portal/account/plans" data-portal="account/plans">Nâng cấp ngay</button>
         {{else}}
-            <button class="gh-btn gh-primary-btn" href="#/portal/signup" data-portal="signup">Subscribe now</button>
-            <span class="gh-cta-link" href="#/portal/signin" data-portal="signin">Already have an account? Sign in.</span>
+            <button class="gh-btn gh-primary-btn" href="#/portal/signup" data-portal="signup">Đăng ký ngay</button>
+            <span class="gh-cta-link" href="#/portal/signin" data-portal="signin">Đã có tài khoản? Đăng nhập.</span>
         {{/if}}
     </div>
 </section>

--- a/partials/pswp.hbs
+++ b/partials/pswp.hbs
@@ -9,13 +9,13 @@
         </div>
 
         <div class="pswp__ui pswp__ui--hidden">
-            <div class="pswp__top-bar">
-                <div class="pswp__counter"></div>
+                <div class="pswp__top-bar">
+                    <div class="pswp__counter"></div>
 
-                <button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
-                <button class="pswp__button pswp__button--share" title="Share"></button>
-                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
-                <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+                    <button class="pswp__button pswp__button--close" title="Đóng (Esc)"></button>
+                    <button class="pswp__button pswp__button--share" title="Chia sẻ"></button>
+                    <button class="pswp__button pswp__button--fs" title="Bật/tắt toàn màn hình"></button>
+                    <button class="pswp__button pswp__button--zoom" title="Phóng to/Thu nhỏ"></button>
 
                 <div class="pswp__preloader">
                     <div class="pswp__preloader__icn">
@@ -30,8 +30,8 @@
                 <div class="pswp__share-tooltip"></div>
             </div>
 
-            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"></button>
-            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"></button>
+                <button class="pswp__button pswp__button--arrow--left" title="Trước (mũi tên trái)"></button>
+                <button class="pswp__button pswp__button--arrow--right" title="Tiếp (mũi tên phải)"></button>
 
             <div class="pswp__caption">
                 <div class="pswp__caption__center"></div>


### PR DESCRIPTION
## Summary
- localize header search/menu labels and newsletter placeholders
- translate PhotoSwipe control titles into Vietnamese

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6e94f5cb08331abfe94e491359031