### PR TITLE
Add view-more button to Giới thiệu section and footer social icons

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -98,7 +98,17 @@
                     {{navigation type="secondary"}}
                 </nav>
             {{/if}}
-           
+            <div class="gh-social">
+                {{#if @custom.facebook_url}}
+                    <a href="{{@custom.facebook_url}}" target="_blank" rel="noopener">{{> "icons/facebook"}}</a>
+                {{/if}}
+                {{#if @custom.youtube_url}}
+                    <a href="{{@custom.youtube_url}}" target="_blank" rel="noopener">{{> "icons/youtube"}}</a>
+                {{/if}}
+                {{#if @custom.tiktok_url}}
+                    <a href="{{@custom.tiktok_url}}" target="_blank" rel="noopener">{{> "icons/tiktok"}}</a>
+                {{/if}}
+            </div>
         </div>
     </footer>
 

--- a/index.hbs
+++ b/index.hbs
@@ -57,16 +57,14 @@
                     <h2 class="gh-section-title">Giới thiệu</h2>
 
                     <div class="gh-about">
-                        {{#if @site.icon}}
-                            <img class="gh-about-icon" src="{{@site.icon}}" alt="{{@site.title}}">
-                        {{/if}}
-
                         <section class="gh-about-wrapper">
                             <h3 class="gh-about-title">{{@site.title}}</h3>
 
                             {{#if @site.description}}
                                 <p class="gh-about-description">{{@site.description}}</p>
                             {{/if}}
+
+                            <a class="gh-about-btn gh-btn" href="/gioi-thieu/">Xem thêm</a>
                         </section>
                     </div>
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,18 @@
                 "type": "select",
                 "options": ["Modern sans-serif", "Elegant serif"],
                 "default": "Modern sans-serif"
+            },
+            "facebook_url": {
+                "type": "text",
+                "default": ""
+            },
+            "youtube_url": {
+                "type": "text",
+                "default": ""
+            },
+            "tiktok_url": {
+                "type": "text",
+                "default": ""
             }
         }
     },


### PR DESCRIPTION
## Summary
- remove site icon from Giới thiệu section
- add button linking to /gioi-thieu/
- add configurable social icons in footer via custom settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f5f8e9688331a59099ce34332493